### PR TITLE
Check for empty container via .empty() instead of with .size()

### DIFF
--- a/src/GPSFix.cpp
+++ b/src/GPSFix.cpp
@@ -87,7 +87,7 @@ double GPSAlmanac::averageSNR(){
 }
 double GPSAlmanac::minSNR(){
 	double min = 9999999;
-	if (satellites.size() == 0){
+	if (satellites.empty()){
 		return 0;
 	}
 	int32_t num_over_zero = 0;
@@ -397,7 +397,7 @@ std::string GPSFix::toString(){
 		<< "   SNR:                avg: " << almanac.averageSNR() << " dB   [min: " << almanac.minSNR() << " dB,  max:" << almanac.maxSNR() << " dB]" << endl;
 
 	ss << " < Almanac (" << almanac.percentComplete() << "%) >" << endl;
-	if (almanac.satellites.size() == 0){
+	if (almanac.satellites.empty()){
 		ss << " > No satellite info in almanac." << endl;
 	}
 	for (size_t i = 0; i < almanac.satellites.size(); i++){

--- a/src/GPSService.cpp
+++ b/src/GPSService.cpp
@@ -31,7 +31,7 @@ double convertLatLongToDeg(string llstr, string dir){
 	deg = deg + mins / 60.0;
 
 	char hdg = 'x';
-	if (dir.size() > 0){
+	if (!dir.empty()){
 		hdg = dir[0];
 	}
 
@@ -152,14 +152,14 @@ void GPSService::read_GPGGA(const NMEASentence& nmea){
 		// LAT
 		sll = nmea.parameters[1];
 		dir = nmea.parameters[2];
-		if (sll.size() > 0){
+		if (!sll.empty()){
 			this->fix.latitude = convertLatLongToDeg(sll, dir);
 		}
 
 		// LONG
 		sll = nmea.parameters[3];
 		dir = nmea.parameters[4];
-		if (sll.size() > 0){
+		if (!sll.empty()){
 			this->fix.longitude = convertLatLongToDeg(sll, dir);
 		}
 
@@ -183,7 +183,7 @@ void GPSService::read_GPGGA(const NMEASentence& nmea){
 		}
 
 		// ALTITUDE
-		if (nmea.parameters[8].size() > 0){
+		if (!nmea.parameters[8].empty()){
 			this->fix.altitude = parseDouble(nmea.parameters[8]);
 		}
 		else {
@@ -414,14 +414,14 @@ void GPSService::read_GPRMC(const NMEASentence& nmea){
 		// LAT
 		sll = nmea.parameters[2];
 		dir = nmea.parameters[3];
-		if (sll.size() > 0){
+		if (!sll.empty()){
 			this->fix.latitude = convertLatLongToDeg(sll, dir);
 		}
 
 		// LONG
 		sll = nmea.parameters[4];
 		dir = nmea.parameters[5];
-		if (sll.size() > 0){
+		if (!sll.empty()){
 			this->fix.longitude = convertLatLongToDeg(sll, dir);
 		}
 
@@ -429,7 +429,7 @@ void GPSService::read_GPRMC(const NMEASentence& nmea){
 		// ACTIVE
 		bool lockupdate = false;
 		char status = 'V';
-		if (nmea.parameters[1].size() > 0){
+		if (!nmea.parameters[1].empty()){
 			status = nmea.parameters[1][0];
 		}
 		this->fix.status = status;

--- a/src/NMEAParser.cpp
+++ b/src/NMEAParser.cpp
@@ -216,7 +216,7 @@ void NMEAParser::readSentence(std::string cmd){
 
 	onInfo(nmea, "Processing NEW string...");
 	
-	if (cmd.size() == 0){
+	if (cmd.empty()){
 		onWarning(nmea, "Blank string -- Skipped processing.");
 		return;
 	}
@@ -323,7 +323,7 @@ uint8_t NMEAParser::calculateChecksum(string s){
 
 void NMEAParser::parseText(NMEASentence& nmea, string txt){
 
-	if (txt.size() == 0){
+	if (txt.empty()){
 		nmea.isvalid = false;
 		return;
 	}
@@ -364,7 +364,7 @@ void NMEAParser::parseText(NMEASentence& nmea, string txt){
 	// Handle comma edge cases
 	size_t comma = txt.find(',');
 	if (comma == string::npos){		//comma not found, but there is a name...
-		if (txt.size() > 0)
+		if (!txt.empty())
 		{	// the received data must just be the name
 			if ( hasNonAlphaNum(txt) ){
 				nmea.isvalid = false;


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,readability-container-size-empty' -fix`