### PR TITLE
Tranform classic loops to range-based for loops

### DIFF
--- a/src/GPSFix.cpp
+++ b/src/GPSFix.cpp
@@ -71,13 +71,13 @@ double GPSAlmanac::averageSNR(){
 
 	double avg = 0;
 	double relevant = 0;
-	for (auto& satellite : satellites){
+	for (const auto& satellite : satellites){
 		if (satellite.snr > 0){
 			relevant += 1.0;
 		}
 	}
 
-	for (auto& satellite : satellites){
+	for (const auto& satellite : satellites){
 		if (satellite.snr > 0){
 			avg += satellite.snr / relevant;
 		}
@@ -91,7 +91,7 @@ double GPSAlmanac::minSNR(){
 		return 0;
 	}
 	int32_t num_over_zero = 0;
-	for (auto& satellite : satellites){
+	for (const auto& satellite : satellites){
 		if (satellite.snr > 0){
 			num_over_zero++;
 			if (satellite.snr < min){
@@ -107,7 +107,7 @@ double GPSAlmanac::minSNR(){
 
 double GPSAlmanac::maxSNR(){
 	double max = 0;
-	for (auto& satellite : satellites){
+	for (const auto& satellite : satellites){
 		if (satellite.snr > 0){
 			if (satellite.snr > max){
 				max = satellite.snr;

--- a/src/GPSFix.cpp
+++ b/src/GPSFix.cpp
@@ -71,15 +71,15 @@ double GPSAlmanac::averageSNR(){
 
 	double avg = 0;
 	double relevant = 0;
-	for (size_t i = 0; i < satellites.size(); i++){
-		if (satellites[i].snr > 0){
+	for (auto& satellite : satellites){
+		if (satellite.snr > 0){
 			relevant += 1.0;
 		}
 	}
 
-	for (size_t i = 0; i < satellites.size(); i++){
-		if (satellites[i].snr > 0){
-			avg += satellites[i].snr / relevant;
+	for (auto& satellite : satellites){
+		if (satellite.snr > 0){
+			avg += satellite.snr / relevant;
 		}
 	}
 
@@ -91,11 +91,11 @@ double GPSAlmanac::minSNR(){
 		return 0;
 	}
 	int32_t num_over_zero = 0;
-	for (size_t i = 0; i < satellites.size(); i++){
-		if (satellites[i].snr > 0){
+	for (auto& satellite : satellites){
+		if (satellite.snr > 0){
 			num_over_zero++;
-			if (satellites[i].snr < min){
-				min = satellites[i].snr;
+			if (satellite.snr < min){
+				min = satellite.snr;
 			}
 		}
 	}
@@ -107,10 +107,10 @@ double GPSAlmanac::minSNR(){
 
 double GPSAlmanac::maxSNR(){
 	double max = 0;
-	for (size_t i = 0; i < satellites.size(); i++){
-		if (satellites[i].snr > 0){
-			if (satellites[i].snr > max){
-				max = satellites[i].snr;
+	for (auto& satellite : satellites){
+		if (satellite.snr > 0){
+			if (satellite.snr > max){
+				max = satellite.snr;
 			}
 		}
 	}

--- a/src/NMEAParser.cpp
+++ b/src/NMEAParser.cpp
@@ -64,7 +64,7 @@ bool NMEASentence::checksumOK() const {
 
 // true if the text contains a non-alpha numeric value
 bool hasNonAlphaNum(string txt){
-	for (char i : txt){
+	for (const char i : txt){
 		if ( !isalnum(i) ){
 			return true;
 		}
@@ -74,7 +74,7 @@ bool hasNonAlphaNum(string txt){
 
 // true if alphanumeric or '-'
 bool validParamChars(string txt){
-	for (char i : txt){
+	for (const char i : txt){
 		if (!isalnum(i)){
 			if (i != '-' && i != '.'){
 				return false;
@@ -88,7 +88,7 @@ bool validParamChars(string txt){
 void squish(string& str){
 
 	char chars[] = {'\t',' '};
-	for (char i : chars)
+	for (const char i : chars)
 	{
 		// needs include <algorithm>
 		str.erase(std::remove(str.begin(), str.end(), i), str.end());
@@ -129,7 +129,7 @@ string NMEAParser::getRegisteredSentenceHandlersCSV()
 	}
 
 	ostringstream ss;
-	for(auto& table : eventTable){
+	for(const auto& table : eventTable){
 		ss << table.first;
 
 		if( ! table.second ){
@@ -188,7 +188,7 @@ void NMEAParser::readBuffer(uint8_t* b, uint32_t size){
 
 void NMEAParser::readLine(string cmd){
 	cmd += "\r\n";
-	for (char i : cmd){
+	for (const char i : cmd){
 		readByte(i);
 	}
 }
@@ -306,7 +306,7 @@ void NMEAParser::readSentence(std::string cmd){
 // then calculates a rolling XOR on the bytes
 uint8_t NMEAParser::calculateChecksum(string s){
 	uint8_t checksum = 0;
-	for (char i : s){
+	for (const char i : s){
 		checksum = checksum ^ i;
 	}
 

--- a/src/NMEAParser.cpp
+++ b/src/NMEAParser.cpp
@@ -64,8 +64,8 @@ bool NMEASentence::checksumOK() const {
 
 // true if the text contains a non-alpha numeric value
 bool hasNonAlphaNum(string txt){
-	for (size_t i = 0; i < txt.size(); i++){
-		if ( !isalnum(txt[i]) ){
+	for (char i : txt){
+		if ( !isalnum(i) ){
 			return true;
 		}
 	}
@@ -74,9 +74,9 @@ bool hasNonAlphaNum(string txt){
 
 // true if alphanumeric or '-'
 bool validParamChars(string txt){
-	for (size_t i = 0; i < txt.size(); i++){
-		if (!isalnum(txt[i])){
-			if (txt[i] != '-' && txt[i] != '.'){
+	for (char i : txt){
+		if (!isalnum(i)){
+			if (i != '-' && i != '.'){
 				return false;
 			}
 		}
@@ -88,10 +88,10 @@ bool validParamChars(string txt){
 void squish(string& str){
 
 	char chars[] = {'\t',' '};
-	for (size_t i = 0; i < sizeof(chars); ++i)
+	for (char i : chars)
 	{
 		// needs include <algorithm>
-		str.erase(std::remove(str.begin(), str.end(), chars[i]), str.end());
+		str.erase(std::remove(str.begin(), str.end(), i), str.end());
 	}
 }
 
@@ -129,10 +129,10 @@ string NMEAParser::getRegisteredSentenceHandlersCSV()
 	}
 
 	ostringstream ss;
-	for( auto it = eventTable.begin(); it != eventTable.end(); it++){
-		ss << it->first;
+	for(auto& table : eventTable){
+		ss << table.first;
 
-		if( ! it->second ){
+		if( ! table.second ){
 			ss << "(not callable)";
 		}
 		ss << ",";
@@ -188,8 +188,8 @@ void NMEAParser::readBuffer(uint8_t* b, uint32_t size){
 
 void NMEAParser::readLine(string cmd){
 	cmd += "\r\n";
-	for (size_t i = 0; i < cmd.size(); ++i){
-		readByte(cmd[i]);
+	for (char i : cmd){
+		readByte(i);
 	}
 }
 
@@ -306,8 +306,8 @@ void NMEAParser::readSentence(std::string cmd){
 // then calculates a rolling XOR on the bytes
 uint8_t NMEAParser::calculateChecksum(string s){
 	uint8_t checksum = 0;
-	for (size_t i = 0; i < s.size(); i++){
-		checksum = checksum ^ s[i];
+	for (char i : s){
+		checksum = checksum ^ i;
 	}
 
 	// will display the calculated checksum in hex


### PR DESCRIPTION
Changes are done by `run-clang-tidy -header-filter='.*' -checks='-*,modernize-loop-convert' -fix`