### PR TITLE
Use pragma once instead of include guards

### DIFF
--- a/include/nmeaparse/Event.h
+++ b/include/nmeaparse/Event.h
@@ -7,8 +7,7 @@
  *  See the license file included with this source.
  */
 
-#ifndef EVENT_H_
-#define EVENT_H_
+#pragma once
 
 #include <list>
 #include <functional>
@@ -213,5 +212,3 @@ namespace nmea {
 
 
 }
-
-#endif /* EVENT_H_ */

--- a/include/nmeaparse/GPSFix.h
+++ b/include/nmeaparse/GPSFix.h
@@ -7,8 +7,7 @@
  *  See the license file included with this source.
  */
 
-#ifndef GPSFIX_H_
-#define GPSFIX_H_
+#pragma once
 
 #include <cstdint>
 #include <ctime>
@@ -178,5 +177,3 @@ namespace nmea {
 	};
 
 }
-
-#endif /* GPSFIX_H_ */

--- a/include/nmeaparse/GPSService.h
+++ b/include/nmeaparse/GPSService.h
@@ -7,8 +7,7 @@
  *  See the license file included with this source.
  */
 
-#ifndef GPSSERVICE_H_
-#define GPSSERVICE_H_
+#pragma once
 
 #include <string>
 #include <chrono>
@@ -43,5 +42,3 @@ public:
 
 
 }
-
-#endif /* GPSSERVICE_H_ */

--- a/include/nmeaparse/NMEACommand.h
+++ b/include/nmeaparse/NMEACommand.h
@@ -7,8 +7,7 @@
  *  See the license file included with this source.
  */
 
-#ifndef NMEACOMMAND_H_
-#define NMEACOMMAND_H_
+#pragma once
 
 #include <string>
 #include <nmeaparse/NMEAParser.h>
@@ -113,5 +112,3 @@ namespace nmea {
 
 
 }
-
-#endif /* NMEACOMMAND_H_ */

--- a/include/nmeaparse/NMEAParser.h
+++ b/include/nmeaparse/NMEAParser.h
@@ -7,9 +7,7 @@
  *  See the license file included with this source.
  */
 
-#ifndef NMEAPARSER_H_
-#define NMEAPARSER_H_
-
+#pragma once
 
 #include <nmeaparse/Event.h>
 #include <string>
@@ -119,5 +117,3 @@ public:
 };
 
 }
-
-#endif /* NMEAPARSER_H_ */

--- a/include/nmeaparse/NumberConversion.h
+++ b/include/nmeaparse/NumberConversion.h
@@ -7,9 +7,7 @@
  *  See the license file included with this source.
  */
 
-#ifndef NUMBERCONVERSION_H_
-#define NUMBERCONVERSION_H_
-
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -43,7 +41,3 @@ int64_t parseInt(std::string s, int radix = 10);
 //void NumberConversion_test();
 
 }
-
-
-
-#endif /* NUMBERCONVERSION_H_ */

--- a/include/nmeaparse/nmea.h
+++ b/include/nmeaparse/nmea.h
@@ -12,19 +12,10 @@
 // The implementation of a NMEA 0183 sentence generator.
 // The implementation of a GPS data service.
 
-
-#ifndef NMEA_H_
-#define NMEA_H_
-
-
+#pragma once
 
 #include <nmeaparse/NMEAParser.h>
 #include <nmeaparse/NMEACommand.h>
 #include <nmeaparse/GPSService.h>
 
 #include <nmeaparse/NumberConversion.h>
-
-
-
-
-#endif //NMEA_H_


### PR DESCRIPTION
> The use of #pragma once can reduce build times as the compiler will not open and read the file after the first #include of the file in the translation unit.

See [here](https://docs.microsoft.com/en-us/cpp/preprocessor/once). As it is supported by all modern compilers since years (see [here](http://en.wikipedia.org/wiki/Pragma_once)), I don't see any real argument against it.