### PR TITLE
Fixed bug when used with qt and localized Strings

### DIFF
--- a/src/NumberConversion.cpp
+++ b/src/NumberConversion.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <nmeaparse/NumberConversion.h>
-#include <cstdlib>
+
 
 using namespace std;
 
@@ -16,30 +16,21 @@ namespace nmea {
 // Note: both parseDouble and parseInt return 0 with "" input.
 
 		double parseDouble(std::string s){
-
-			char* p;
-			double d = ::strtod(s.c_str(), &p);
-			if (*p != 0){
-				std::stringstream ss;
-				ss << "NumberConversionError: parseDouble() error in argument \"" << s << "\", '"
-					<< *p << "' is not a number.";
-				throw NumberConversionError(ss.str());
-			}
-			return d;
-		}
-		int64_t parseInt(std::string s, int radix){
-			char* p;
-
-			int64_t d = ::strtoll(s.c_str(), &p, radix);
-
-			if (*p != 0) {
-				std::stringstream ss;
-				ss << "NumberConversionError: parseInt() error in argument \"" << s << "\", '"
-					<< *p << "' is not a number.";
-				throw NumberConversionError(ss.str());
-			}
-			return d;
-		}
+            try{
+                return std::stod(s);
+            }
+            catch(std::exception&){
+                throw NumberConversionError("NumberConversionError: parseDouble() error in argument \"" +s+"' it is not a number.");
+            }
+	}
+        int64_t parseInt(std::string s, int radix){
+            try{
+                return std::stoll(s,nullptr,radix);
+            }
+            catch(std::exception&){
+                throw NumberConversionError("NumberConversionError: parseDouble() error in argument \"" +s+"' it is not a number.");
+            }
+	}
 
 }
 


### PR DESCRIPTION
When parsing with c methods, localized floats are a problem. 
Use the more reliable c++  11 string parsefunctions.