### PR TITLE
Fix Non-GPS Messages

### DIFF
--- a/src/GPSService.cpp
+++ b/src/GPSService.cpp
@@ -92,6 +92,62 @@ void GPSService::attachToParser(NMEAParser& _parser){
 		this->read_GPVTG(nmea);
 	});
 
+    // https://anavs.com/knowledgebase/nmea-format/
+
+//    * GP for GPS only solutions
+//    * GL for GLONASS only solutions
+//    * GA for GALILEO only solutions
+//    * GN for multi GNSS solutions
+
+
+    _parser.setSentenceHandler("GLGGA", [this](const NMEASentence& nmea){
+        this->read_GPGGA(nmea);
+    });
+    _parser.setSentenceHandler("GLGSA", [this](const NMEASentence& nmea){
+        this->read_GPGSA(nmea);
+    });
+    _parser.setSentenceHandler("GLGSV", [this](const NMEASentence& nmea){
+        this->read_GPGSV(nmea);
+    });
+    _parser.setSentenceHandler("GLRMC", [this](const NMEASentence& nmea){
+        this->read_GPRMC(nmea);
+    });
+    _parser.setSentenceHandler("GLVTG", [this](const NMEASentence& nmea){
+        this->read_GPVTG(nmea);
+    });
+
+    _parser.setSentenceHandler("GAGGA", [this](const NMEASentence& nmea){
+        this->read_GPGGA(nmea);
+    });
+    _parser.setSentenceHandler("GAGSA", [this](const NMEASentence& nmea){
+        this->read_GPGSA(nmea);
+    });
+    _parser.setSentenceHandler("GAGSV", [this](const NMEASentence& nmea){
+        this->read_GPGSV(nmea);
+    });
+    _parser.setSentenceHandler("GARMC", [this](const NMEASentence& nmea){
+        this->read_GPRMC(nmea);
+    });
+    _parser.setSentenceHandler("GAVTG", [this](const NMEASentence& nmea){
+        this->read_GPVTG(nmea);
+    });
+
+
+    _parser.setSentenceHandler("GNGGA", [this](const NMEASentence& nmea){
+        this->read_GPGGA(nmea);
+    });
+    _parser.setSentenceHandler("GNGSA", [this](const NMEASentence& nmea){
+        this->read_GPGSA(nmea);
+    });
+    _parser.setSentenceHandler("GNGSV", [this](const NMEASentence& nmea){
+        this->read_GPGSV(nmea);
+    });
+    _parser.setSentenceHandler("GNRMC", [this](const NMEASentence& nmea){
+        this->read_GPRMC(nmea);
+    });
+    _parser.setSentenceHandler("GNVTG", [this](const NMEASentence& nmea){
+        this->read_GPVTG(nmea);
+    });
 }
 
 

--- a/src/NMEAParser.cpp
+++ b/src/NMEAParser.cpp
@@ -440,6 +440,8 @@ void NMEAParser::parseText(NMEASentence& nmea, string txt){
 		sz << "Found " << nmea.parameters.size() << " parameters.";
 		onInfo(nmea, sz.str());
 
+        	string tmp_str;
+
 		//possible checksum at end...
 		size_t endi = nmea.parameters.size() - 1;
 		size_t checki = nmea.parameters[endi].find_last_of('*');
@@ -450,7 +452,17 @@ void NMEAParser::parseText(NMEASentence& nmea, string txt){
 				onError(nmea, "Checksum '*' character at end, but no data.");
 			}
 			else{
-				nmea.checksum = last.substr(checki + 1, last.size() - checki);		//extract checksum without '*'
+
+                //extract checksum without '*' and \n,\r
+
+                // copy into temporary string
+                tmp_str = last.substr(checki + 1, last.size() - checki);
+
+                // remove superflous line breaks and carriage returns
+                tmp_str.erase(std::remove(tmp_str.begin(), tmp_str.end(), '\n'),tmp_str.end());
+                tmp_str.erase(std::remove(tmp_str.begin(), tmp_str.end(), '\r'),tmp_str.end());
+
+                nmea.checksum = tmp_str;
 
 				onInfo(nmea, string("Found checksum. (\"*") + nmea.checksum + "\")");
 
@@ -461,10 +473,10 @@ void NMEAParser::parseText(NMEASentence& nmea, string txt){
 				}
 				catch( NumberConversionError& )
 				{
-					onError(nmea, string("parseInt() error. Parsed checksum string was not readable as hex. (\"") +  nmea.checksum + "\")");
+                    onError(nmea, string("parseInt() error. Parsed checksum string was not readable as hex. (\"") +  nmea.checksum + "\")");
 				}
 				
-				onInfo(nmea, string("Checksum ok? ") + (nmea.checksumOK() ? "YES" : "NO") + "!");
+                onInfo(nmea, string("Checksum ok? ") + (nmea.checksumOK() ? "YES" : "NO") + "!");
 				
 
 			}


### PR DESCRIPTION
- Removed checksum line-breaks and carriage returns (happened in some test files)
- Added non-GPS message handlers (same format, different prefix)

Apologies if the formatting got messed up, I use spaces not tabs for intend.