### PR TITLE
Fix member initialization order in class EventHandler 

### DIFF
--- a/include/nmeaparse/Event.h
+++ b/include/nmeaparse/Event.h
@@ -58,7 +58,7 @@ namespace nmea {
 		// (none)
 
 		// Functions
-		EventHandler(std::function<void(Args...)> h) : _iterator(), handler(h), ID(++LastID)
+		EventHandler(std::function<void(Args...)> h) : _iterator(), ID(++LastID), handler(h) 
 		{}
 
 		EventHandler(const EventHandler& ref){


### PR DESCRIPTION
- fix: initialization order to suppress -Wreorder warnings

matching member initialization order to that of declaration.