### PR TITLE
Adding GN message compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is all you need to use the GPS NMEA sentence data.
 
   - Standard:
 ```` 
-    GPGGA, GPGSA, GPGSV, GPRMC, GPVTG
+    GPGGA, GPGSA, GPGSV, GPRMC, GPVTG, GNGGA, GNGSA, GNGSV, GNRMC, GNVTG
 ````
 
 * **NMEA Generation** of "standard" and custom sentences.

--- a/include/nmeaparse/GPSService.h
+++ b/include/nmeaparse/GPSService.h
@@ -23,11 +23,11 @@ class GPSService {
 private:
 
 	void read_PSRF150(const NMEASentence& nmea);
-	void read_GPGGA	(const NMEASentence& nmea);
-	void read_GPGSA	(const NMEASentence& nmea);
-	void read_GPGSV	(const NMEASentence& nmea);
-	void read_GPRMC	(const NMEASentence& nmea);
-	void read_GPVTG	(const NMEASentence& nmea);
+	void read_GGA	(const NMEASentence& nmea);
+	void read_GSA	(const NMEASentence& nmea);
+	void read_GSV	(const NMEASentence& nmea);
+	void read_RMC	(const NMEASentence& nmea);
+	void read_VTG	(const NMEASentence& nmea);
 
 public:
 	GPSFix fix;

--- a/src/GPSService.cpp
+++ b/src/GPSService.cpp
@@ -77,21 +77,35 @@ void GPSService::attachToParser(NMEAParser& _parser){
 		this->read_PSRF150(nmea);
 	});
 	_parser.setSentenceHandler("GPGGA", [this](const NMEASentence& nmea){
-		this->read_GPGGA(nmea);
+		this->read_GGA(nmea);
 	});
 	_parser.setSentenceHandler("GPGSA", [this](const NMEASentence& nmea){
-		this->read_GPGSA(nmea);
+		this->read_GSA(nmea);
 	});
 	_parser.setSentenceHandler("GPGSV", [this](const NMEASentence& nmea){
-		this->read_GPGSV(nmea);
+		this->read_GSV(nmea);
 	});
 	_parser.setSentenceHandler("GPRMC", [this](const NMEASentence& nmea){
-		this->read_GPRMC(nmea);
+		this->read_RMC(nmea);
 	});
 	_parser.setSentenceHandler("GPVTG", [this](const NMEASentence& nmea){
-		this->read_GPVTG(nmea);
+		this->read_VTG(nmea);
 	});
-
+	_parser.setSentenceHandler("GNGGA", [this](const NMEASentence& nmea){
+		this->read_GGA(nmea);
+	});
+	_parser.setSentenceHandler("GNGSA", [this](const NMEASentence& nmea){
+		this->read_GSA(nmea);
+	});
+	_parser.setSentenceHandler("GNGSV", [this](const NMEASentence& nmea){
+		this->read_GSV(nmea);
+	});
+	_parser.setSentenceHandler("GNRMC", [this](const NMEASentence& nmea){
+		this->read_RMC(nmea);
+	});
+	_parser.setSentenceHandler("GNVTG", [this](const NMEASentence& nmea){
+		this->read_VTG(nmea);
+	});
 }
 
 
@@ -103,7 +117,7 @@ void GPSService::read_PSRF150(const NMEASentence& nmea){
 	// Called with checksum 3F (invalid) for GPS turning OFF
 }
 
-void GPSService::read_GPGGA(const NMEASentence& nmea){
+void GPSService::read_GGA(const NMEASentence& nmea){
 	/* -- EXAMPLE --
 	$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47
 
@@ -208,7 +222,7 @@ void GPSService::read_GPGGA(const NMEASentence& nmea){
 	}
 }
 
-void GPSService::read_GPGSA(const NMEASentence& nmea){
+void GPSService::read_GSA(const NMEASentence& nmea){
 	/*  -- EXAMPLE --
 	$GPGSA,A,3,04,05,,09,12,,,24,,,,,2.5,1.3,2.1*39
 
@@ -282,7 +296,7 @@ void GPSService::read_GPGSA(const NMEASentence& nmea){
 	}
 }
 
-void GPSService::read_GPGSV(const NMEASentence& nmea){
+void GPSService::read_GSV(const NMEASentence& nmea){
 	/*  -- EXAMPLE --
 	$GPGSV,2,1,08,01,40,083,46,02,17,308,41,12,07,344,39,14,22,228,45*75
 
@@ -376,7 +390,7 @@ void GPSService::read_GPGSV(const NMEASentence& nmea){
 	}
 }
 
-void GPSService::read_GPRMC(const NMEASentence& nmea){
+void GPSService::read_RMC(const NMEASentence& nmea){
 	/*  -- EXAMPLE ---
 	$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A
 	$GPRMC,235957.025,V,,,,,,,070810,,,N*4B
@@ -467,7 +481,7 @@ void GPSService::read_GPRMC(const NMEASentence& nmea){
 	}
 }
 
-void GPSService::read_GPVTG(const NMEASentence& nmea){
+void GPSService::read_VTG(const NMEASentence& nmea){
 	/*
 	$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*48
 


### PR DESCRIPTION
Looking at more modern system `$GN` messages are more and more common, but are parsed the same way as `$GP` ones.